### PR TITLE
Declare bluebird as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
   "keywords": [],
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org/)",
   "devDependencies": {},
+  "peerDependencies": {
+    "bluebird": "^2.0.0 || ^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "bluebird": {
+      "optional": true
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iarna/promise-inflight.git"


### PR DESCRIPTION
Fixes #3 and Yarn 2 error:
> [MODULE_NOT_FOUND] Error: promise-inflight tried to access bluebird, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.